### PR TITLE
fix: not allow user to choose past date and time for auction creation

### DIFF
--- a/create_auction.php
+++ b/create_auction.php
@@ -101,7 +101,15 @@ mysqli_close($connection);
           <div class="col-sm-10">
             <input type="datetime-local" class="form-control" name="auctionEndDate" id="auctionEndDate" required>
           </div>
-        </div>
+        </div> 
+        <script>
+          const endDateInput = document.getElementById('auctionEndDate');
+          const now = new Date();
+          const localDateTime = new Date(now.getTime() - now.getTimezoneOffset() * 60000)
+            .toISOString()
+            .slice(0, 16);
+          endDateInput.setAttribute('min', localDateTime);
+        </script>
         <button type="submit" class="btn btn-primary form-control">Create Auction</button>
       </form>
     </div>


### PR DESCRIPTION
Add Javascript to the frontend form to forbid user from choosing a past date and time when create an auction.
Past date will be greyed out. Even if they can select a past time, form will prompt error message. 
<img width="544" alt="Screenshot 2024-11-15 at 22 09 34" src="https://github.com/user-attachments/assets/8f406c18-ecdb-48da-83b3-269080f274a7">
<img width="945" alt="Screenshot 2024-11-15 at 22 09 59" src="https://github.com/user-attachments/assets/ac65e16d-123a-4600-8df5-01fadb603c06">