### PR TITLE
Fix the issue where bid count was always shown as 1 on all pages

### DIFF
--- a/utilities.php
+++ b/utilities.php
@@ -25,7 +25,7 @@ function print_listing_li($item_id, $title, $currentPrice, $num_bids, $end_time)
 {
 
   // Fix language of bid vs. bids
-  if ($num_bids = 1) {
+  if ($num_bids <= 1) {
     $bid = ' bid';
   } else {
     $bid = ' bids';


### PR DESCRIPTION
Bug fix: $num_bids was always overwritten to 1 in print_listing_li, leading to the bid count was always shown as 1 on all pages.

