### PR TITLE
feat: watchlist for buyers

### DIFF
--- a/email_auction_end.php
+++ b/email_auction_end.php
@@ -4,17 +4,14 @@ include_once("email_utilities.php");
 
 $conn = get_connection();
 
-// Step 1: Find auctions that have ended but are still active
 $query = "SELECT * FROM Auctions WHERE endDate < NOW() AND auctionStatus = 1";
 $auctions = execute_query($conn, $query);
 
-// Step 2: Process each auction
 while ($auction = mysqli_fetch_assoc($auctions)) {
     $auction_id = $auction['auctionID'];
     $auction_title = $auction['title'];
     $seller_id = $auction['sellerID'];
 
-    // Step 3: Get all bids for this auction and order by bidPrice descending (highest first)
     $bids_query = "
         SELECT 
             b.bidID,
@@ -32,79 +29,78 @@ while ($auction = mysqli_fetch_assoc($auctions)) {
 
     $bids_result = execute_query($conn, $bids_query);
 
-    // Step 4: If no bids, notify the seller and skip the auction
     if (mysqli_num_rows($bids_result) == 0) {
-        // Notify seller that no one bid on their auction
         $seller_query = "SELECT email FROM Users WHERE userID = $seller_id";
         $seller_result = execute_query($conn, $seller_query);
         $seller_email = mysqli_fetch_assoc($seller_result)['email'];
 
-        // Send notification to the seller
         send_email_by_type($seller_email, 'no_bids_notification', ['auction_title' => $auction_title]);
 
-        // Skip to the next auction
         continue;
     }
 
-    // Step 5: Process the bids (only if there are bids)
     $winner_email = "";
     $seller_email = "";
     $outbid_bidders = [];
     $highest_bid = null;
 
-    // First, fetch the highest bid (winner) and the other bidders
     $is_first_bid = true;
     while ($bid = mysqli_fetch_assoc($bids_result)) {
-        $bid_status = 'outbid';  // Default to outbid
+        $bid_status = 'outbid';
 
         if ($is_first_bid) {
-            // The first bid (highest bid) is the winner
             $bid_status = 'winner';
-            $winner_email = $bid['bidder_email']; // Store winner email
-            $highest_bid = $bid['bidID']; // Store the highest bid ID
+            $winner_email = $bid['bidder_email'];
+            $highest_bid = $bid['bidID'];
             $is_first_bid = false;
         }
 
-        // Add to outbid list for all non-winners
         if ($bid_status == 'outbid') {
             $outbid_bidders[] = $bid['bidder_email'];
         }
 
-        // Update the bid status in the database (all others as outbid)
         $update_bid_sql = "UPDATE Bids SET isSuccessful = 0 WHERE bidID = {$bid['bidID']}";
         execute_query($conn, $update_bid_sql);
     }
 
-    // Mark the highest bid as successful
     if ($highest_bid) {
         $update_bid_sql = "UPDATE Bids SET isSuccessful = 1 WHERE bidID = $highest_bid";
         execute_query($conn, $update_bid_sql);
     }
 
-    // Step 6: Get the seller's email
     $seller_query = "SELECT email FROM Users WHERE userID = $seller_id";
     $seller_result = execute_query($conn, $seller_query);
     $seller_email = mysqli_fetch_assoc($seller_result)['email'];
 
-    // Step 7: Send notifications
-
-    // Notify the winner
     if ($winner_email) {
         send_email_by_type($winner_email, 'auction_closed_winner', ['auction_title' => $auction_title]);
     }
 
-    // Notify the seller
     if ($seller_email) {
         send_email_by_type($seller_email, 'auction_closed_seller', ['auction_title' => $auction_title]);
     }
 
-    // Notify the outbid bidders
     send_email_by_type($outbid_bidders, 'auction_closed_bidders', ['auction_title' => $auction_title]);
 
-    // Mark auction as completed (inactive)
+    $watcher_query = "
+    SELECT DISTINCT Users.email
+    FROM Watchlists
+    INNER JOIN Users ON Watchlists.buyerID = Users.userID
+    WHERE Watchlists.auctionID = $auction_id AND Users.email != '$winner_email'";
+
+    $watcher_result = execute_query($conn, $watcher_query);
+    while ($watcher = mysqli_fetch_assoc($watcher_result)) {
+        $watcher_emails[] = $watcher['email'];
+    }
+
+    if (!empty($watcher_emails)) {
+        send_email_by_type($watcher_emails, 'watchlist_update_notification', ['auction_title' => $auction_title]);
+    }
+
+    $watcher_emails = [];
+
     $update_auction_sql = "UPDATE Auctions SET auctionStatus = 0 WHERE auctionID = $auction_id";
     execute_query($conn, $update_auction_sql);
 }
 
-// Close the database connection
 close_connection($conn);

--- a/email_utilities.php
+++ b/email_utilities.php
@@ -64,30 +64,40 @@ function send_email($recipients, $subject, $body)
     }
 }
 
-// Send email to all bidders who are outbidded - including querying those bidders inside this function
-function send_multiple_outbid_email($conn, $auction_id, $current_bidder_id, $bid_amount, $auction_title)
+function send_auction_update_emails($conn, $auction_id, $current_bidder_id, $bid_amount, $auction_title, $notification_type)
 {
-    // Query to find other bidders who were outbid, excluding the current highest bidder
-    $outbid_query = "
-        SELECT DISTINCT Users.email
-        FROM Bids
-        INNER JOIN Users ON Bids.buyerID = Users.userID
-        WHERE Bids.auctionID = $auction_id
-          AND Bids.buyerID != $current_bidder_id
-          AND Bids.bidPrice < $bid_amount";
-
-    $outbid_result = execute_query($conn, $outbid_query);
-
-    // Collect outbid emails into an array
-    $outbid_emails = [];
-    while ($row = mysqli_fetch_assoc($outbid_result)) {
-        $outbid_emails[] = $row['email'];
+    if ($notification_type === 'outbid_notification') {
+        $query = "
+            SELECT DISTINCT Users.email
+            FROM Bids
+            INNER JOIN Users ON Bids.buyerID = Users.userID
+            WHERE Bids.auctionID = $auction_id
+              AND Bids.buyerID != $current_bidder_id
+              AND Bids.bidPrice < $bid_amount";
+    } else if ($notification_type === 'watchlist_update_notification') {
+        $query = "
+            SELECT DISTINCT Users.email
+            FROM Watchlists
+            INNER JOIN Users ON Watchlists.buyerID = Users.userID
+            WHERE Watchlists.auctionID = $auction_id
+              AND Users.userID != $current_bidder_id";
+    } else {
+        return;
     }
 
-    // Check if there are outbid users to notify
-    if (!empty($outbid_emails)) {
-        // Send a single outbid notification email to all outbid users
-        send_email_by_type($outbid_emails, 'outbid_notification', ['auction_title' => $auction_title]);
+    $result = execute_query($conn, $query);
+
+    $emails = [];
+    while ($row = mysqli_fetch_assoc($result)) {
+        $emails[] = $row['email'];
+    }
+
+    if (!empty($emails)) {
+        send_email_by_type(
+            $emails,
+            $notification_type,
+            ['auction_title' => $auction_title, 'bid_amount' => $bid_amount]
+        );
     }
 }
 
@@ -97,39 +107,43 @@ function get_email_content($type, $data = [])
     $templates = [
         'registration' => [
             'subject' => "Welcome to Auction Site!",
-            'body' => "Hi,\r\n\r\nWelcome to our auction site!\r\nYour account was created successfully!\r\n\r\nBest regards,\r\nAuctionCat Team"
+            'body' => "Hi,\r\n\r\nWelcome to our auction site!\r\nYour account was created successfully!\r\n\r\nBest regards,\r\nEbibi Team"
         ],
         'create_auction' => [
             'subject' => "Your Auction Has Been Successfully Created!",
-            'body' => "Hello,\r\n\r\nCongratulations! Your auction '{auction_title}' has been successfully created and is now live for bidders to view. We wish you the best of luck in attracting great bids!\r\n\r\nThank you for choosing AuctionCat,\r\nAuctionCat Team"
+            'body' => "Hello,\r\n\r\nCongratulations! Your auction '{auction_title}' has been successfully created and is now live for bidders to view. We wish you the best of luck in attracting great bids!\r\n\r\nThank you for choosing Ebibi,\r\nEbibi Team"
         ],
         'create_bid' => [
             'subject' => "Your Bid Was Successfully Created!",
-            'body' => "Hello,\r\n\r\nYour bid for '{auction_title}' has been successfully placed. Keep an eye on your bid to stay in the lead!\r\n\r\nThank you for participating,\r\nAuctionCat Team"
+            'body' => "Hello,\r\n\r\nYour bid for '{auction_title}' has been successfully placed. Keep an eye on your bid to stay in the lead!\r\n\r\nThank you for participating,\r\nEbibi Team"
         ],
         'successful_bid' => [
             'subject' => "Your Bid Was Successful!",
-            'body' => "Hello,\r\n\r\nYour recent bid for '{auction_title}' was successful. Keep bidding for more items!\r\n\r\nBest regards,\r\nAuctionCat Team"
+            'body' => "Hello,\r\n\r\nYour recent bid for '{auction_title}' was successful. Keep bidding for more items!\r\n\r\nBest regards,\r\nEbibi Team"
         ],
         'outbid_notification' => [
             'subject' => "You've Been Outbid!",
-            'body' => "Hello,\r\n\r\nSomeone has outbid you on auction '{auction_title}'. Return to the auction site to increase your bid!\r\n\r\nBest regards,\r\nAuctionCat Team"
+            'body' => "Hello,\r\n\r\nSomeone has outbid you on auction '{auction_title}'. Return to the auction site to increase your bid!\r\n\r\nBest regards,\r\nEbibi Team"
         ],
         'auction_closed_winner' => [
             'subject' => "Congratulations, You Won the Auction!",
-            'body' => "Hello,\r\n\r\nCongratulations on winning the auction '{auction_title}'! Log in to view the details.\r\n\r\nBest regards,\r\nAuctionCat Team"
+            'body' => "Hello,\r\n\r\nCongratulations on winning the auction '{auction_title}'! Log in to view the details.\r\n\r\nBest regards,\r\nEbibi Team"
         ],
         'auction_closed_bidders' => [
             'subject' => "Auction Closed: {auction_title}",
-            'body' => "Hello,\r\n\r\nThe auction for '{auction_title}' has closed. Another user won the auction.\r\n\r\nThank you for participating,\r\nAuctionCat Team"
+            'body' => "Hello,\r\n\r\nThe auction for '{auction_title}' has closed. Another user won the auction.\r\n\r\nThank you for participating,\r\nEbibi Team"
         ],
         'no_bids_notification' => [
             'subject' => "Your Auction '{auction_title}' Didn't Receive Any Bids",
-            'body' => "Hello,\r\n\r\nUnfortunately, no one placed any bids on your auction '{auction_title}'. Better luck next time!\r\n\r\nBest regards,\r\nAuctionCat Team"
+            'body' => "Hello,\r\n\r\nUnfortunately, no one placed any bids on your auction '{auction_title}'. Better luck next time!\r\n\r\nBest regards,\r\nEbibi Team"
         ],
         'auction_closed_seller' => [
             'subject' => "Your Auction '{auction_title}' Has Ended",
-            'body' => "Hello,\r\n\r\nWe wanted to inform you that your auction '{auction_title}' has officially ended.\r\n\r\nPlease log in to your account to check the results.\r\n\r\nIf you have any questions or need assistance, feel free to reach out to us.\r\n\r\nBest regards,\r\nAuctionCat Team"
+            'body' => "Hello,\r\n\r\nWe wanted to inform you that your auction '{auction_title}' has officially ended.\r\n\r\nPlease log in to your account to check the results.\r\n\r\nIf you have any questions or need assistance, feel free to reach out to us.\r\n\r\nBest regards,\r\nEbibi Team"
+        ],
+        'watchlist_update_notification' => [
+            'subject' => "Update on an Auction in Your Watchlist: '{auction_title}'",
+            'body' => "Hello,\r\n\r\nWe wanted to let you know that there's been a recent update to the auction '{auction_title}' that you're watching. \r\n\r\nPlease log in to view the latest changes and ensure you stay informed about any new bids, adjustments, or important details.\r\n\r\nThank you for staying engaged,\r\nEbibi Team"
         ]
     ];
 

--- a/listing.php
+++ b/listing.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 include_once("header.php");
 require("utilities.php");
 require("database.php");
@@ -63,8 +63,9 @@ if ($now < $end_time) {
 }
 
 $has_session = session_status() == PHP_SESSION_ACTIVE ? true : false;
-$watching = false;
 
+$can_watchlist = isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true && isset($_SESSION['account_type']) && $_SESSION['account_type'] === 'buyer';
+$watching = $can_watchlist ? check_is_watching($connection, $item_id, $_SESSION['user_id']) : false;
 ?>
 
 <div class="container">
@@ -75,9 +76,11 @@ $watching = false;
     </div>
     <div class="col-sm-4 align-self-center"> <!-- Right col -->
       <?php if ($now < $end_time): ?>
-        <div id="watch_nowatch" <?php if ($has_session && $watching) echo 'style="display: none"'; ?>>
-          <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addToWatchlist()">+ Add to watchlist</button>
-        </div>
+        <?php if ($can_watchlist): ?>
+          <div id="watch_nowatch" <?php if ($has_session && $watching) echo 'style="display: none"'; ?>>
+            <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addToWatchlist()">+ Add to watchlist</button>
+          </div>
+        <?php endif; ?>
         <div id="watch_watching" <?php if (!$has_session || !$watching) echo 'style="display: none"'; ?>>
           <button type="button" class="btn btn-success btn-sm" disabled>Watching</button>
           <button type="button" class="btn btn-danger btn-sm" onclick="removeFromWatchlist()">Remove watch</button>

--- a/place_bid.php
+++ b/place_bid.php
@@ -59,12 +59,11 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
         if (execute_query($conn, $query)) {
             $_SESSION['success_message'] = 'Your bid has been placed successfully!';
-            // send email to success bid for current user
             if (isset($_SESSION['email']) && !empty($_SESSION['email'])) {
                 send_email_by_type($_SESSION['email'], 'successful_bid', ['auction_title' => $auction_title]);
             }
-            // queue the emails for noticing the outbidded users
-            send_multiple_outbid_email($conn, $item_id, $buyer_id, $bid_price, $auction_title);
+            send_auction_update_emails($conn, $item_id, $buyer_id, $bid_price, $auction_title, 'watchlist_update_notification');
+            send_auction_update_emails($conn, $item_id, $buyer_id, $bid_price, $auction_title, 'outbid_notification');
         } else {
             $_SESSION['warning_message'] = 'There was an error placing your bid. Please try again.';
         }

--- a/sql_scripts/create-table-template.sql
+++ b/sql_scripts/create-table-template.sql
@@ -92,7 +92,7 @@ CREATE TABLE Orders(
 
 CREATE TABLE Watchlists(
     buyerID INT NOT NULL,
-    auctionID INT NULL NULL,
+    auctionID INT NOT NULL,
     FOREIGN KEY (auctionID) REFERENCES Auctions(auctionID),
     FOREIGN KEY (buyerID) REFERENCES Buyers(buyerID)
 );

--- a/utilities.php
+++ b/utilities.php
@@ -87,15 +87,15 @@ function print_my_listings_li($item_id, $title, $currentPrice, $num_bids, $end_t
   }
 
   // Conditional colouring for auction status
-  $status_colour = match($auction_status) {
-      'Sold' => 'green',
-      'Reserve not met' => 'orange',
-      'Open' => 'grey',
-      'Closed - No bids' => 'black'
+  $status_colour = match ($auction_status) {
+    'Sold' => 'green',
+    'Reserve not met' => 'orange',
+    'Open' => 'grey',
+    'Closed - No bids' => 'black'
   };
 
   // Print HTML
-     echo "
+  echo "
     <li class='list-group-item'>
         <div class='row ml-1 mt-2 mb-1'>
             <div class='col-4'>
@@ -134,7 +134,7 @@ function print_my_bids_listing($item_id, $title, $highestBid, $userBid, $num_bid
     $time_remaining = display_time_remaining($time_to_end) . ' remaining';
   }
 
-   $status_colour = match($auctionStatus) {
+  $status_colour = match ($auctionStatus) {
     'Won' => 'green',
     'Closed' => 'black',
     'Open' => 'grey'
@@ -329,21 +329,21 @@ function render_bid_history_table($bid_history_result, $starting_price, $created
       </tr>
     </thead>
     <tbody>
-      <?php 
-      if (mysqli_num_rows($bid_history_result) > 0): 
+      <?php
+      if (mysqli_num_rows($bid_history_result) > 0):
         // Fetch the first (latest) bid
-        $is_first_row = true; 
-        while ($row = mysqli_fetch_assoc($bid_history_result)): 
+        $is_first_row = true;
+        while ($row = mysqli_fetch_assoc($bid_history_result)):
       ?>
           <tr class="border <?php echo $is_first_row ? 'font-weight-bold' : ''; ?>">
             <td><?php echo htmlspecialchars(mask_username($row['username'])); ?></td>
             <td><?php echo htmlspecialchars(format_price($row['bidPrice'])); ?></td>
             <td><?php echo htmlspecialchars($row['bidDate']); ?></td>
           </tr>
-          <?php 
+        <?php
           // Once we hit the first row (latest bid), set $is_first_row to false
           $is_first_row = false;
-          endwhile; 
+        endwhile;
         ?>
         <tr class="border">
           <td>Starting Price</td>
@@ -460,7 +460,7 @@ function get_recommended_auctions_sql($user_id, $count_mode)
  */
 function get_popular_auctions_sql($user_id, $count_mode)
 {
-    $query_auctions_select_clause = "
+  $query_auctions_select_clause = "
         SELECT 
             a.auctionID,
             a.title,
@@ -468,13 +468,13 @@ function get_popular_auctions_sql($user_id, $count_mode)
             COUNT(b.bidID) AS bidCount,
             a.endDate
     ";
-    $count_select_clause = "SELECT COUNT(DISTINCT a.auctionID) AS total ";
+  $count_select_clause = "SELECT COUNT(DISTINCT a.auctionID) AS total ";
 
-    // Choose the SELECT clause based on count mode
-    $result_sql = $count_mode ? $count_select_clause : $query_auctions_select_clause;
+  // Choose the SELECT clause based on count mode
+  $result_sql = $count_mode ? $count_select_clause : $query_auctions_select_clause;
 
-    // Add the logic for retrieving popular live auctions
-    $result_sql .= "
+  // Add the logic for retrieving popular live auctions
+  $result_sql .= "
         FROM 
             Auctions a
         LEFT JOIN 
@@ -489,17 +489,27 @@ function get_popular_auctions_sql($user_id, $count_mode)
             )
     ";
 
-    // If not in count mode, aggregate results and order by bid count
-    if (!$count_mode) {
-        $result_sql .= "
+  // If not in count mode, aggregate results and order by bid count
+  if (!$count_mode) {
+    $result_sql .= "
         GROUP BY 
             a.auctionID, a.title, a.endDate
         ORDER BY 
             bidCount DESC, a.endDate ASC  -- Most popular auctions first, tiebreaker is soonest ending
         ";
-    }
+  }
 
-    // Return the final query, parameters, and parameter types
-    return [$result_sql, [$user_id], 'i'];
+  // Return the final query, parameters, and parameter types
+  return [$result_sql, [$user_id], 'i'];
 }
 
+function check_is_watching($connection, $auction_id, $user_id)
+{
+  $watcher_query = "SELECT 1 FROM Watchlists WHERE buyerID = $user_id AND auctionID = $auction_id LIMIT 1";
+  $watcher_result = execute_query($connection, $watcher_query);
+
+  if (mysqli_num_rows($watcher_result) > 0) {
+    return true;
+  }
+  return false;
+}

--- a/watchlist_funcs.php
+++ b/watchlist_funcs.php
@@ -1,27 +1,41 @@
  <?php
 
-if (!isset($_POST['functionname']) || !isset($_POST['arguments'])) {
-  return;
-}
+  include_once('utilities.php');
+  include_once('database.php');
 
-// Extract arguments from the POST variables:
-$item_id = $_POST['arguments'];
+  if (!isset($_POST['functionname']) || !isset($_POST['arguments'])) {
+    return;
+  }
 
-if ($_POST['functionname'] == "add_to_watchlist") {
-  // TODO: Update database and return success/failure.
+  session_start();
 
-  $res = "success";
-}
-else if ($_POST['functionname'] == "remove_from_watchlist") {
-  // TODO: Update database and return success/failure.
+  if (empty($_SESSION['logged_in']) || $_SESSION['account_type'] !== 'buyer') {
+    return;
+  }
 
-  $res = "success";
-}
+  $user_id = (int)$_SESSION['user_id'];
+  $item_id = (int)$_POST['arguments'][0];
+  $conn = get_connection();
 
-// Note: Echoing from this PHP function will return the value as a string.
-// If multiple echo's in this file exist, they will concatenate together,
-// so be careful. You can also return JSON objects (in string form) using
-// echo json_encode($res).
-echo $res;
+  if ($_POST['functionname'] == "add_to_watchlist") {
+    $add_watchlist_sql = "INSERT INTO Watchlists (buyerID, auctionID) VALUES ($user_id, $item_id)";
+    $add_result = execute_query($conn, $add_watchlist_sql);
+    if ($add_result) {
+      $res = "success";
+    } else {
+      $res = "error";
+    }
+  } else if ($_POST['functionname'] == "remove_from_watchlist") {
+    $remove_watchlist_sql = "DELETE FROM Watchlists WHERE buyerID = $user_id AND auctionID = $item_id";
+    $remove_result = execute_query($conn, $remove_watchlist_sql);
+    if ($remove_result) {
+      $res = "success";
+    } else {
+      $res = "error";
+    }
+  }
 
-?>
+  close_connection($conn);
+  echo $res;
+
+  ?>


### PR DESCRIPTION
Implemented Watchlist Functionality:
- Only buyers can add auctions/items to their watchlist for simplicity.
- Users who are not logged in and sellers cannot see the "Add to Watchlist" button.
- When a new bid is placed, an email is sent to all buyers who are watching the auction/item (excluding the bidder if they are also watching).
- When an auction ends, an email is sent to all buyers who are watching the auction/item (you need to run the bash script).

Notes:
- The email messages for the watchlist feature are currently quite vague (e.g., "There’s been a recent update to the auction...") and do not account for specific scenarios (e.g., "The auction you're watching has ended" or "A new bid has been placed"). This was done for simplicity and due to time constraints.
- The solutions implemented may not be the most elegant.
- We can refactor this if we have time.

Miscellaneous:
- Changed all `AuctionCat` in email messages to `Ebibi`.